### PR TITLE
Avoid evaluating {dverse} in the title

### DIFF
--- a/posts/zzz_DO_NOT_EDIT_document_yo.../document_your_universe_with_dverse.qmd
+++ b/posts/zzz_DO_NOT_EDIT_document_yo.../document_your_universe_with_dverse.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Creating a better universe with {dverse}"
+title: "Creating a better universe with dverse"
 author:
   - name: Mauro Lepore
 description: "How to create a global search across an entire collection of R packages: A use case for the toy 'admiralverse'"


### PR DESCRIPTION
* Fixes https://github.com/pharmaverse/blog/pull/257#issuecomment-2541202620

<details><summary>reprex</summary>

```r
# R/update_post_dates.R L 34:
# cli::cli_inform(paste("Date updated on post:", yaml_list$title))

# Fails
title <- "Creating a better universe with {dverse}"
yaml_list <- list(title = title)
cli::cli_inform(paste("Date updated on post:", yaml_list$title))
#> Error in "lapply(text, glue_cmd, .envir = .envir)": ! Could not evaluate cli `{}` expression: `dverse`.
#> Caused by error in `eval(expr, envir = envir)`:
#> ! object 'dverse' not found

# Solution
title <- "Creating a better universe with dverse"
yaml_list <- list(title = title)
cli::cli_inform(paste("Date updated on post:", yaml_list$title))
#> Date updated on post: Creating a better universe with dverse

# Considered
title <- "Creating a better universe with {{dverse}}"
yaml_list <- list(title = title)
cli::cli_inform(paste("Date updated on post:", yaml_list$title))
#> Date updated on post: Creating a better universe with {dverse}
```

</details>

From the possible solutions I choose to simply remove `{}`. I also considered escaping with `{{}}` but then the blog would show the literal `{{}}`.

<details>

![image](https://github.com/user-attachments/assets/ce261ab4-9751-4560-8200-81b8d091b6c1)


<details>



