### PR TITLE
Use canonical `long_slug` pattern

### DIFF
--- a/posts/2025-08-13_rtflite_1.0.0/rtflite.qmd
+++ b/posts/2025-08-13_rtflite_1.0.0/rtflite.qmd
@@ -15,7 +15,7 @@ image: logo.png
 <!--------------- typical setup ----------------->
 
 ```{r setup, include=FALSE}
-long_slug <- "2025-08-11_rtflite_1.0.0..."
+long_slug <- "zzz_DO_NOT_EDIT_rtflite_1.0.0"
 library(link)
 link::auto()
 ```


### PR DESCRIPTION
This PR is a quick follow-up to #322 - only one small change to use the canonical `long_slug` format (`zzz_DO_NOT_EDIT_` prefix) in all previous posts, so that the blog post URL can be correctly set to:


```text
https://pharmaverse.github.io/blog/posts/2025-08-13_rtflite_1.0.0/rtflite.html
```

instead of the current:

```text
https://pharmaverse.github.io/blog/posts/zzz_DO_NOT_EDIT_rtflite_1.0.0/rtflite.html
```